### PR TITLE
Add continuous integration with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# dump_ciede2000 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/KyleSiefring/dump_ciede2000?branch=master&svg=true)](https://ci.appveyor.com/project/KyleSiefring/dump_ciede2000)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+image: Visual Studio 2017
+
+ environment:
+  host: x86_64-pc-windows-msvc        # Triple of host platform
+  matrix:
+    - platform: x86_64                # Name (is not used other than naming things)
+      target: x86_64-pc-windows-msvc  # Triple of target platform
+      channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
+    - platform: arm64
+      target: aarch64-pc-windows-msvc 
+      channel: stable
+matrix:
+  allow_failures:                     # Allows jobs with these variables to fail
+    - platform: arm64
+
+ install:
+    - git submodule update --init
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
+    - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
+    - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%        # Adds Rust tools (Cargo, Rustup, etc.) to path
+    - rustc -vV                       # Prints Rust version
+    - cargo -vV                       # Prints Cargo version
+    - rustup target add %target%      # Adds target platform to Rust
+
+ build_script:
+    - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
+
+ test_script:
+    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
+#    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
+
+ artifacts:                          
+    - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
+      name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
+
+ deploy:
+  - provider: GitHub
+    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2017
 
- environment:
+environment:
   host: x86_64-pc-windows-msvc        # Triple of host platform
   matrix:
     - platform: x86_64                # Name (is not used other than naming things)
@@ -13,7 +13,7 @@ matrix:
   allow_failures:                     # Allows jobs with these variables to fail
     - platform: arm64
 
- install:
+install:
     - git submodule update --init
     - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
     - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
@@ -22,18 +22,18 @@ matrix:
     - cargo -vV                       # Prints Cargo version
     - rustup target add %target%      # Adds target platform to Rust
 
- build_script:
+build_script:
     - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
 
- test_script:
+test_script:
     - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
 #    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
 
- artifacts:                          
+artifacts:                          
     - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
       name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
 
- deploy:
+deploy:
   - provider: GitHub
     artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
     auth_token:


### PR DESCRIPTION
Adds continuous integration with AppVeyor for automated Windows builds ([example](https://ci.appveyor.com/project/EwoutH/dump-ciede2000/history)).

For optimal integration with GitHub, AppVeyor needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.

When enabled, AppVeyor publishes the artifacts with each build. When tagging a new (pre)release, AppVeyor will also upload `dump_ciede2000.exe`, `dump_ciede2000.d` and `dump_ciede2000.pdb` to GitHub, creating a nice release page [like this](https://github.com/EwoutH/dump_ciede2000/releases/tag/0.1.1-test1).

To enable uploading to GitHub Releases, you need update this patch with your personal authentication token. You can generate one on https://github.com/settings/tokens/new (select `public_repo` as scope), and then encrypt it with https://ci.appveyor.com/tools/encrypt. Replace the current token on line 40 (after `secure:`) in the `appveyor.yml` file. 