### PR TITLE
Fix resolve errors with unicode-width in clap/clap_builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 y4m = "0.3"
-clap = {version = "2", default-features = false}
+clap = { version = "3.0.0", features = ["derive"] }
 lab = "0.6.0"
 itertools = "0.8.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,14 +65,14 @@ fn parse_cli() -> CliOptions {
         .arg(
             Arg::with_name("LIMIT")
                 .help("Maximum number of frames to process")
-                .short("l")
+                .short('l')
                 .long("limit")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("SUMMARY")
                 .help("Only output the summary line")
-                .short("s")
+                .short('s')
                 .long("summary"),
         )
         .arg(


### PR DESCRIPTION
This PR fixes the following issues encountered during compilation:
- Rust Compiler Version: rustc 1.64.0 (a55dd71d5 2022-09-19)
- Error Context:
Errors were raised in the unicode-width crate, which is used by clap_builder. The errors are related to the use of the unstable library feature mixed_integer_ops.

```
112.3 error[E0658]: use of unstable library feature 'mixed_integer_ops'
112.3    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/unicode-width-0.1.14/src/tables.rs:407:22
112.3     |
112.3 407 |                 (sum.wrapping_add_signed(isize::from(add)), info)
112.3     |                      ^^^^^^^^^^^^^^^^^^^
112.3     |
112.3     = note: see issue #87840 <https://github.com/rust-lang/rust/issues/87840> for more information
112.3
```